### PR TITLE
new Dockerfile to power the Cloudant backups

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,0 +1,6 @@
+# https://github.com/apache/openwhisk/blob/master/docs/actions-docker.md
+FROM ibmfunctions/action-nodejs-v10
+
+RUN npm install ibm-cos-sdk@1.6.1
+RUN npm install @cloudant/couchbackup
+


### PR DESCRIPTION
Here's a new Dockerfile for an image that needs `@cloudant/couchbackup` and the `ibm-cos-sdk` modules.

This will be used as the basis of the IBM Cloud Function action that runs to perform nightly backups of our Cloudant databases.